### PR TITLE
Fix incorrect API key portal URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Both APIs support:
 - **API Keys** (recommended) - Per-app, revocable, secure
 - **Local Secrets** - Shared secret for trusted local network
 
-API keys created at [Indigo Account Portal](https://accounts.indigodomo.com).
+API keys created at [Indigo Account Portal](https://www.indigodomo.com/account/).
 
 ## Requirements
 

--- a/docs/integration/authentication.md
+++ b/docs/integration/authentication.md
@@ -22,7 +22,7 @@ Complete guide to authenticating with Indigo's WebSocket and HTTP APIs using API
 
 ### Creating an API Key
 
-1. Visit [Indigo Account Portal](https://accounts.indigodomo.com)
+1. Visit [Indigo Account Portal](https://www.indigodomo.com/account/)
 2. Log in with your Indigo account
 3. Navigate to "API Keys" section
 4. Click "Create New API Key"
@@ -221,7 +221,7 @@ https://REFLECTOR.indigodomo.net/v2/api/indigo.devices
 **Solutions**:
 - Verify "Start Local Server" is enabled in preferences
 - Check firewall allows port 8176 (local) or 443 (Reflector)
-- Confirm Reflector ID at accounts.indigodomo.com
+- Confirm Reflector ID at https://www.indigodomo.com/account/
 
 ### WebSocket Connection Drops Immediately
 

--- a/skill.md
+++ b/skill.md
@@ -175,7 +175,7 @@ Both APIs use **API Keys** or **Local Secrets**:
 
 - [Official API Documentation](https://wiki.indigodomo.com/doku.php?id=indigo_2025.1_documentation:api)
 - [Indigo Forum](https://forums.indigodomo.com/)
-- [Indigo Account Portal](https://accounts.indigodomo.com) - Create API keys
+- [Indigo Account Portal](https://www.indigodomo.com/account/) - Create API keys
 
 ## Version Information
 


### PR DESCRIPTION
## Description

Corrects the API key portal URL throughout the documentation from the incorrect `accounts.indigodomo.com` to the proper `https://www.indigodomo.com/account/`.

## Changes

- ✅ **README.md**: Updated API key creation link
- ✅ **skill.md**: Fixed external resources link
- ✅ **docs/integration/authentication.md**: Corrected portal links in setup instructions and troubleshooting section

## Verification

According to the [official Indigo 2025.1 API documentation](https://wiki.indigodomo.com/doku.php?id=indigo_2025.1_documentation:api), the correct URL is `www.indigodomo.com/account/authorizations`.

## Testing

- [x] All file references updated
- [x] No remaining instances of incorrect URL
- [x] Links point to correct Indigo account portal

Fixes #1

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Indigo Account Portal links in README and authentication documentation to direct users to the correct portal location for account management and API key creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->