### PR TITLE
Clarify command availability may differ between transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Connect Indigo to other services:
 - Perfect for occasional access
 
 ### Same Commands, Two Transports
-Both APIs use identical command messages - choose the transport that fits your use case.
+Both APIs support the core command messages documented here, though some commands may be specific to one transport. Choose the transport that fits your use case.
 
 ## Authentication
 

--- a/docs/integration/device-commands.md
+++ b/docs/integration/device-commands.md
@@ -2,6 +2,8 @@
 
 Complete reference for all device commands available via WebSocket and HTTP APIs.
 
+> **Note on Command Availability:** The commands documented here are primarily tested with the WebSocket API and are generally available in both transports. However, some commands may be transport-specific. If a command doesn't work in your chosen transport, try the alternative or consult the official Indigo documentation.
+
 ## Command Message Structure
 
 All commands use this JSON format:

--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -155,6 +155,17 @@ Both APIs support the same authentication methods:
    - HTTP: [http-api.md](http-api.md)
 4. **Command reference**: [device-commands.md](device-commands.md)
 
+## API Feature Parity
+
+While both APIs provide access to core Indigo functionality (devices, variables, action groups), there are some differences:
+
+### Known Differences:
+- **Folders**: HTTP API includes folder objects; WebSocket handles folders differently
+- **Command Availability**: Some commands may be specific to one transport
+- **Data Structure**: Response formats are generally consistent but may vary in edge cases
+
+**Recommendation:** For critical functionality, test with your target transport to verify command availability. The official Indigo wiki may not fully document all differences.
+
 ## Can I Use Both?
 
 **Yes!** Many applications combine both APIs:

--- a/skill.md
+++ b/skill.md
@@ -129,11 +129,13 @@ This skill contains focused API documentation (~50KB). Load selectively based on
    - Best for: Scripts, webhooks, periodic checks
    - Use when: Occasional commands or polling is acceptable
 
-### Same Commands, Two Transports
+### Command Messages Across Transports
 
-Both APIs use the **same command messages** (documented in `device-commands.md`):
+The APIs share most command messages (documented in `device-commands.md`), though some commands may be specific to one transport:
 - WebSocket sends commands via persistent connection
 - HTTP sends commands via POST to `/v2/api/command`
+
+**Note:** While the core device, dimmer, variable, and action group commands are available in both APIs, some advanced commands may only be available via HTTP or WebSocket. Consult the official Indigo documentation for transport-specific commands.
 
 ### Authentication
 


### PR DESCRIPTION
## Summary
- Remove incorrect assumptions that WebSocket and HTTP APIs have identical command structures
- Add appropriate caveats about transport-specific commands
- Recommend testing for critical functionality

## Changes
- **README.md**: Update "Same Commands, Two Transports" section to note some commands may be transport-specific
- **skill.md**: Rename section to "Command Messages Across Transports" and add note about potential differences
- **overview.md**: Add new "API Feature Parity" section documenting known differences (folders, command availability, data structures)
- **device-commands.md**: Add prominent note at top about command availability and testing recommendations

## Rationale
The documentation previously claimed that both APIs use "identical" or "the same" command messages, which is not accurate. In practice, some commands are specific to one transport. This update:
- Removes definitive claims about complete parity
- Acknowledges documentation gaps
- Encourages developers to test with their target transport
- Is honest about what we know and don't know

## Test plan
- [x] Verified all instances of "identical" removed
- [x] Verified all instances of "same command" updated
- [x] Added appropriate caveats in all relevant files
- [x] Documentation tone is appropriately cautious

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified command availability across WebSocket and HTTP transports
  * Added API Feature Parity guide detailing compatibility differences between transport APIs
  * Enhanced authentication documentation with explicit configuration examples
  * Updated guidance on transport-specific commands and fallback options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->