### PR TITLE
docs: add control page rendering URL

### DIFF
--- a/docs/integration/websocket-api.md
+++ b/docs/integration/websocket-api.md
@@ -298,8 +298,8 @@ See [device-commands.md](device-commands.md) for complete command reference.
 
 **Connection URLs**:
 ```
-ws://localhost:8176/v2/api/ws/page-feed
-wss://YOUR-REFLECTOR-NAME.indigodomo.net/v2/api/ws/page-feed
+ws://192.168.1.100:8176/v2/api/ws/page-feed
+wss://{REFLECTOR}.indigodomo.net/v2/api/ws/page-feed
 ```
 
 ### Rendering Control Pages in a Browser/WebView
@@ -307,16 +307,22 @@ wss://YOUR-REFLECTOR-NAME.indigodomo.net/v2/api/ws/page-feed
 To display a control page's rendered content, load the following URL in a browser or WKWebView:
 
 ```
-http://localhost:8176/web/controlpage.html?id={pageID}
-https://YOUR-REFLECTOR-NAME.indigodomo.net/web/controlpage.html?id={pageID}
+http://192.168.1.100:8176/web/controlpage.html?id={pageID}
+https://{REFLECTOR}.indigodomo.net/web/controlpage.html?id={pageID}
 ```
 
 For example, a page with ID `963336187` would be:
 ```
-https://my-reflector.indigodomo.net/web/controlpage.html?id=963336187
+https://{REFLECTOR}.indigodomo.net/web/controlpage.html?id=963336187
 ```
 
-Authentication is required via `Authorization: Bearer {API_KEY}` header.
+Authentication is required via `Authorization: Bearer {API_KEY}` header. In a WKWebView, inject the header using a `URLRequest`:
+
+```swift
+var request = URLRequest(url: url)
+request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+webView.load(request)
+```
 
 ### Control Page Object Structure
 
@@ -353,7 +359,7 @@ Received when a new control page is added to the Indigo Server after the connect
 {
   "message": "add",
   "objectType": "indigo.ControlPage",
-  "objectDict": {}  // ControlPage object as outlined above
+  "objectDict": { ... }
 }
 ```
 
@@ -366,11 +372,11 @@ Received when a control page has been updated on the Indigo server. Does not all
   "message": "patch",
   "objectType": "indigo.ControlPage",
   "objectId": 963336187,
-  "patch": {}  // dictdiffer patch object - see Object Patches section
+  "patch": [["change", "name", ["Old Name", "New Name"]]]
 }
 ```
 
-Patch objects are created via the `dictdiffer` Python module, by comparing the control page dictionary for the old page with the new dictionary as received in the `control_page_updated()` Plugin method call.
+Patch objects use `dictdiffer` format. See the Object Patches section above for details on applying patches.
 
 ### Delete Control Page Message
 

--- a/docs/integration/websocket-api.md
+++ b/docs/integration/websocket-api.md
@@ -294,11 +294,95 @@ See [device-commands.md](device-commands.md) for complete command reference.
 
 ## Control Page Feed
 
-**Read-only feed** - provides updates about control pages but does not accept commands.
+**Read-only feed** - used for managing a list of available control pages. No command messages can be sent; its purpose is to use incoming messages to manage a list of available control pages which the user can select to open.
 
-Pages with `remoteDisplay: true` will generate add/patch/delete messages.
+**Connection URLs**:
+```
+ws://localhost:8176/v2/api/ws/page-feed
+wss://YOUR-REFLECTOR-NAME.indigodomo.net/v2/api/ws/page-feed
+```
 
-Use for building custom UI that mirrors Indigo's control pages.
+### Rendering Control Pages in a Browser/WebView
+
+To display a control page's rendered content, load the following URL in a browser or WKWebView:
+
+```
+http://localhost:8176/web/controlpage.html?id={pageID}
+https://YOUR-REFLECTOR-NAME.indigodomo.net/web/controlpage.html?id={pageID}
+```
+
+For example, a page with ID `963336187` would be:
+```
+https://my-reflector.indigodomo.net/web/controlpage.html?id=963336187
+```
+
+Authentication is required via `Authorization: Bearer {API_KEY}` header.
+
+### Control Page Object Structure
+
+```json
+{
+  "class": "indigo.ControlPage",
+  "backgroundImage": "",
+  "description": "",
+  "folderId": 0,
+  "globalProps": {},
+  "hideTabBar": true,
+  "id": 963336187,
+  "name": "Weather Images",
+  "pluginProps": {},
+  "remoteDisplay": true,
+  "sharedProps": {}
+}
+```
+
+### Refresh Control Pages
+
+```json
+{
+  "message": "refresh",
+  "objectType": "indigo.ControlPage"
+}
+```
+
+### Add Control Page Message
+
+Received when a new control page is added to the Indigo Server after the connection is opened, or when a control page's `remoteDisplay` property is changed from `false` to `true`.
+
+```json
+{
+  "message": "add",
+  "objectType": "indigo.ControlPage",
+  "objectDict": {}  // ControlPage object as outlined above
+}
+```
+
+### Update Control Page Message (Patch)
+
+Received when a control page has been updated on the Indigo server. Does not allow users to update control pages via the WebSocket API.
+
+```json
+{
+  "message": "patch",
+  "objectType": "indigo.ControlPage",
+  "objectId": 963336187,
+  "patch": {}  // dictdiffer patch object - see Object Patches section
+}
+```
+
+Patch objects are created via the `dictdiffer` Python module, by comparing the control page dictionary for the old page with the new dictionary as received in the `control_page_updated()` Plugin method call.
+
+### Delete Control Page Message
+
+Received when a control page is deleted from the Indigo server, or when a control page's `remoteDisplay` property is set from `true` to `false`.
+
+```json
+{
+  "message": "delete",
+  "objectType": "indigo.ControlPage",
+  "objectId": 123456789
+}
+```
 
 ## Log Feed
 


### PR DESCRIPTION
## Summary

- Document the URL path for rendering control pages in a browser/WebView (`/web/controlpage.html?id={pageID}`)
- Covers both local and reflector URLs with authentication requirements

## Test plan

- [ ] Verify documentation is accurate against a running Indigo server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Control Page Feed docs with detailed connection URLs, browser/WebView rendering guidance, example page IDs, and a full Control Page JSON object.
  * Added message specs and example payloads for Refresh, Add, Update (Patch) and Delete operations, including remoteDisplay state notes and patch semantics.
  * Documented authentication (Bearer token) requirements for page-related requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->